### PR TITLE
Support for Laravel 5.4 and null data types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "illuminate/mail": "5.1.* || 5.2.* || 5.3.*"
+        "illuminate/mail": "5.1.* || 5.2.* || 5.3.* || 5.4.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/MailProvider.php
+++ b/src/MailProvider.php
@@ -14,13 +14,30 @@ class MailProvider extends MailServiceProvider
      */
     public function registerSwiftMailer()
     {
-        if ($this->app['config']['mail.driver'] === 'null') {
+        if ($this->isDriverNull()) {
             return $this->registerNullSwiftMailer();
         }
 
         parent::registerSwiftMailer();
     }
 
+    /**
+     * Predicate that determines whether the driver is set as a null string or
+     * null data type
+     * @method isDriverNull
+     * @return bool
+     */
+    private function isDriverNull()
+    {
+        if ($this->app['config']['mail.driver'] === 'null') {
+            return true;
+        } elseif (is_null($this->app['config']['mail.driver'])) {
+            return true;
+        }
+
+        return false;
+    }
+    
     /**
      * Register the Null Swift Mailer instance.
      *


### PR DESCRIPTION
Two changes:

* Updated the composer.json requirements to support Laravel 5.4
* Added support for the mail config variable being a null data type instead of just a null string (this fixes an issue where driver would not initialise if the env var was set in phpunit.xml as the string "null" was converted to a null value). 


PS:  @pascalbaljet thank you for the package - I'm surprised it is not more popular.